### PR TITLE
replace feedburner with contact form 7

### DIFF
--- a/assets/functions/admin.php
+++ b/assets/functions/admin.php
@@ -50,9 +50,9 @@ if (!function_exists('theme_webprofile_gplus_id')) {
   }
 }
 
-if (!function_exists('theme_webprofile_feedburner')) {
-  function theme_webprofile_feedburner($_echo = true) {
-    get_theme_option('webprofile_feedburner', $_echo);
+if (!function_exists('theme_webprofile_form')) {
+  function theme_webprofile_form($_echo = true) {
+    get_theme_option('webprofile_form', $_echo);
   }
 }
 

--- a/assets/functions/options.php
+++ b/assets/functions/options.php
@@ -34,7 +34,7 @@ function theme_options_do_page() {
           'webprofile_twitter' => '',
           'webprofile_facebook' => '',
           'webprofile_linkedin_id' => '',
-          'webprofile_feedburner' => '',
+          'webprofile_form' => '',
           'url_social_facebook' => 'http://facebook.com/',
           'url_social_twitter' => 'http://twitter.com/',
           'url_social_gplus' => '',
@@ -101,9 +101,9 @@ function theme_options_do_page() {
           </td>
         </tr>
 
-        <tr valign="top"><th scope="row"><?php _e( 'Feedburner - Endereço Feed', 'wptheme-rdblog' ); ?></th>
+        <tr valign="top"><th scope="row"><?php _e( 'Código do Formulário', 'wptheme-rdblog' ); ?></th>
           <td>
-            <input id="rd-mkt_theme_options[webprofile_feedburner]" class="regular-text" type="text" name="rd-mkt_theme_options[webprofile_feedburner]" placeholder="<?php esc_attr_e( $default_options['webprofile_feedburner'] ); ?>" value="<?php esc_attr_e( ($options['options_edited'] != 'true') ? $default_options['webprofile_feedburner'] : $options['webprofile_feedburner'] ); ?>" />
+            <input id="rd-mkt_theme_options[webprofile_form]" class="regular-text" type="text" name="rd-mkt_theme_options[webprofile_form]" placeholder="<?php esc_attr_e( $default_options['webprofile_form'] ); ?>" value="<?php esc_attr_e( ($options['options_edited'] != 'true') ? $default_options['webprofile_form'] : $options['webprofile_form'] ); ?>" />
           </td>
         </tr>
       </table>

--- a/footer.php
+++ b/footer.php
@@ -45,11 +45,7 @@
                 <li><a href="<?php theme_url_social_instagram(); ?>" title="Instagram" target="_blank"><i class="fa fa-instagram"></i></a></li>
               <?php } ?>
 
-              <?php if ( is_option_setted('webprofile_feedburner') ) { ?>
-                <li><a href="http://feeds.feedburner.com/<?php theme_webprofile_feedburner(); ?>" class="rss-icon" target="_blank"><i class="fa fa-rss-square"></i></a></li>
-              <?php } else { ?>
-                <li><a href="<?php bloginfo('rss2_url'); ?>" class="rss-icon" target="_blank"><i class="fa fa-rss-square"></i></a></li>
-              <?php } ?>
+              <li><a href="<?php bloginfo('rss2_url'); ?>" class="rss-icon" target="_blank"><i class="fa fa-rss-square"></i></a></li>
 
               <?php if ( is_option_setted('url_social_mail') ) { ?>
                 <li><a href="mailto:<?php theme_url_social_mail(); ?>"><i class="fa fa-envelope"></i></a></li>

--- a/header.php
+++ b/header.php
@@ -8,11 +8,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no">
   <?php wp_head(); ?>
 
-  <?php if ( is_option_setted('webprofile_feedburner') ) { ?>
-    <link rel="alternate" type="application/rss+xml" title="Feed RSS" href="http://feeds.feedburner.com/<?php theme_webprofile_feedburner(); ?>" />
-  <?php } else { ?>
-    <link rel="alternate" type="application/rss+xml" title="Feed RSS" href="<?php bloginfo('rss2_url'); ?>" />
-  <?php } ?>
+  <link rel="alternate" type="application/rss+xml" title="Feed RSS" href="<?php bloginfo('rss2_url'); ?>" />
   <link rel="pingback" href="<?php bloginfo('pingback_url'); ?>" />
 
   <link rel="stylesheet" type="text/css" href="<?php echo get_stylesheet_uri(); ?>" />
@@ -91,22 +87,12 @@
 
   <section id="about-subscribe">
     <div class="container">
-      <?php if ( is_option_setted('webprofile_feedburner') ) { ?>
-        <div class="pure-g-r feedburner-area">
+      <?php if ( is_option_setted('webprofile_form') ) { ?>
+        <div class="pure-g-r newsletter-area">
           <div class="pure-u-2-3">
             <div class="l-box">
               <h2><?php if ( is_option_setted('header_desc') ) { theme_header_desc(); } ?></h2>
             </div>
-          </div>
-          <div class="pure-u-1-3">
-            <h3>Assine nossos posts</h3>
-            <form action="http://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('http://feedburner.google.com/fb/a/mailverify?uri=<?php theme_webprofile_feedburner(); ?>', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true">
-              <p>
-                <input type="text" placeholder="Endereço de email" name="email"/>
-                <input type="submit" value="Enviar"/>
-                <input type="hidden" value="<?php theme_webprofile_feedburner(); ?>" name="uri"/><input type="hidden" name="loc" value="pt_BR"/>
-              </p>
-            </form>
           </div>
         </div>
       <?php } else { ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,14 +1,11 @@
 <div id="sidebar" class="pure-u-1-3">
-  <?php if ( is_archive() || is_search() && is_option_setted('webprofile_feedburner') ) { ?>
+  <?php if ( is_option_setted('webprofile_form') ) { ?>
     <div class="white-container sidebar-widget">
       <h3>Assine nossos posts</h3>
-      <form action="http://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="window.open('http://feedburner.google.com/fb/a/mailverify?uri=<?php theme_webprofile_feedburner(); ?>', 'popupwindow', 'scrollbars=yes,width=550,height=520');return true">
-        <p>
-          <input type="text" placeholder="Endereço de email" name="email"/>
-          <input type="submit" value="Enviar"/>
-          <input type="hidden" value="<?php theme_webprofile_feedburner(); ?>" name="uri"/><input type="hidden" name="loc" value="pt_BR"/>
-        </p>
-      </form>
+      <?php
+        $form_id = theme_webprofile_form(false);
+        echo do_shortcode('[contact-form-7 id="'.$form_id.'" title="Newsletter"]');
+      ?>
     </div>
   <?php } ?>
   <?php if ( is_option_setted('webprofile_twitter') || is_option_setted('webprofile_facebook') || is_option_setted('webprofile_gplus_id') || is_option_setted('webprofile_linkedin_id') ) { ?>


### PR DESCRIPTION
Substituindo o feedburner pelo Contact Form 7. 

Agora é possível utilizar um formulário do Contact Form 7  (com outros campos) ao invés do formulário com apenas o campo de e-mail. Este formulário será integrado ao RD Station, e os dados não irão mais para o feedburner.

Por se tratar de um formulário que pode ter mais de um campo, ele foi removido do header, ficando apenas na sidebar.
